### PR TITLE
12.show message user needs root privilage to check firewall status

### DIFF
--- a/SysScope.py
+++ b/SysScope.py
@@ -98,7 +98,10 @@ def check_open_ports():
 
 
 def show_firewall_status():
-    subprocess.run(["ufw", "status"])
+    try:
+        subprocess.run(["ufw", "status"], check = True, stderr=subprocess.DEVNULL, text=True)
+    except subprocess.CalledProcessError:
+        print(Fore.RED + "Um diese Aktion auszuführen, benötigen Sie Root-Rechte von Ihrem Betriebssystem. Führen Sie bitte „sudo python SysScope“ aus und wählen Sie 12. Firewall-Status anzeigen")
 
 
 def show_system_time():


### PR DESCRIPTION
added the error message : 

"Um diese Aktion auszuführen, benötigen Sie Root-Rechte von Ihrem Betriebssystem. Führen Sie bitte „sudo python SysScope“ aus und wählen Sie 12. Firewall-Status anzeigen" 

To inform the user to use root privileges (sudo) when checking the firewall status(12. Firewall-Status anzeigen) if they haven't done so